### PR TITLE
Workaround to optimizes the Inverted IQ Operation

### DIFF
--- a/SX126x.cpp
+++ b/SX126x.cpp
@@ -636,6 +636,16 @@ void SX126x::SetPacketParams(const PacketParams_t& packetParams )
 			buf[3] = packetParams.Params.LoRa.PayloadLength;
 			buf[4] = packetParams.Params.LoRa.CrcMode;
 			buf[5] = packetParams.Params.LoRa.InvertIQ;
+
+			// WORKAROUND - Optimizing the Inverted IQ Operation, see DS_SX1261-2_V1.2 datasheet chapter 15.4
+			if(packetParams.Params.LoRa.InvertIQ == RadioLoRaIQModes_t::LORA_IQ_INVERTED)
+			{
+				WriteReg(REG_IQ_POLARITY, ReadReg(REG_IQ_POLARITY) & ~(1 << 2));
+			}
+			else
+			{
+				WriteReg(REG_IQ_POLARITY, ReadReg(REG_IQ_POLARITY) | ( 1 << 2 ));
+			}
 			break;
 		default:
 		case PACKET_TYPE_NONE:

--- a/SX126x.hpp
+++ b/SX126x.hpp
@@ -178,7 +178,12 @@ public:
 		/*!
 		 * Set the current max value in the over current protection
 		 */
-		REG_OCP = 0x08E7
+		REG_OCP = 0x08E7,
+
+		/*!
+		 * IQ polarity setup, optimize the inverted IQ operation
+		 */
+		REG_IQ_POLARITY = 0x0736,
 
 	};
 public:


### PR DESCRIPTION
Implement workaround that optimizes the Inverted IQ Operation (see DS_SX1261-2_V1.2 datasheet chapter 15.4)

