### PR TITLE
Workaround modulation quality 500khz

### DIFF
--- a/SX126x.cpp
+++ b/SX126x.cpp
@@ -572,15 +572,15 @@ void SX126x::SetModulationParams(const ModulationParams_t& modulationParams )
 			buf[2] = modulationParams.Params.LoRa.CodingRate;
 			buf[3] = modulationParams.Params.LoRa.LowDatarateOptimize;
 
-                        // WORKAROUND - Modulation Quality with 500 kHz LoRa Bandwidth, see DS_SX1261-2_V1.2 datasheet chapter 15.1
-                        if(modulationParams.PacketType == RadioPacketTypes_t::PACKET_TYPE_LORA && modulationParams.Params.LoRa.Bandwidth == RadioLoRaBandwidths_t::LORA_BW_500 )
-                        {
-                        	WriteReg(REG_TX_MODULATION, ReadReg(REG_TX_MODULATION) & ~(1 << 2));
-                        }
-                        else
-                        {
-                        	WriteReg( REG_TX_MODULATION, ReadReg( REG_TX_MODULATION ) | (1 << 2));
-                        }
+			// WORKAROUND - Modulation Quality with 500 kHz LoRa Bandwidth, see DS_SX1261-2_V1.2 datasheet chapter 15.1
+			if(modulationParams.PacketType == RadioPacketTypes_t::PACKET_TYPE_LORA && modulationParams.Params.LoRa.Bandwidth == RadioLoRaBandwidths_t::LORA_BW_500 )
+			{
+				WriteReg(REG_TX_MODULATION, ReadReg(REG_TX_MODULATION) & ~(1 << 2));
+			}
+			else
+			{
+				WriteReg( REG_TX_MODULATION, ReadReg( REG_TX_MODULATION ) | (1 << 2));
+			}
 			break;
 		default:
 		case PACKET_TYPE_NONE:

--- a/SX126x.cpp
+++ b/SX126x.cpp
@@ -571,6 +571,16 @@ void SX126x::SetModulationParams(const ModulationParams_t& modulationParams )
 			buf[1] = modulationParams.Params.LoRa.Bandwidth;
 			buf[2] = modulationParams.Params.LoRa.CodingRate;
 			buf[3] = modulationParams.Params.LoRa.LowDatarateOptimize;
+
+                        // WORKAROUND - Modulation Quality with 500 kHz LoRa Bandwidth, see DS_SX1261-2_V1.2 datasheet chapter 15.1
+                        if(modulationParams.PacketType == RadioPacketTypes_t::PACKET_TYPE_LORA && modulationParams.Params.LoRa.Bandwidth == RadioLoRaBandwidths_t::LORA_BW_500 )
+                        {
+                        	WriteReg(REG_TX_MODULATION, ReadReg(REG_TX_MODULATION) & ~(1 << 2));
+                        }
+                        else
+                        {
+                        	WriteReg( REG_TX_MODULATION, ReadReg( REG_TX_MODULATION ) | (1 << 2));
+                        }
 			break;
 		default:
 		case PACKET_TYPE_NONE:

--- a/SX126x.hpp
+++ b/SX126x.hpp
@@ -180,10 +180,10 @@ public:
 		 */
 		REG_OCP = 0x08E7,
 
-        	/*!
-        	 * TX modulation quality optimization
-        	*/
-        	REG_TX_MODULATION = 0x0889
+		/*!
+		 * TX modulation quality optimization
+		*/
+		REG_TX_MODULATION = 0x0889
 
 	};
 public:

--- a/SX126x.hpp
+++ b/SX126x.hpp
@@ -178,7 +178,12 @@ public:
 		/*!
 		 * Set the current max value in the over current protection
 		 */
-		REG_OCP = 0x08E7
+		REG_OCP = 0x08E7,
+
+        	/*!
+        	 * TX modulation quality optimization
+        	*/
+        	REG_TX_MODULATION = 0x0889
 
 	};
 public:


### PR DESCRIPTION
 Implement the workaround that improves the modulation quality with 500Khz LoRa bandwidth (see DS_SX1261-2_V1.2 datasheet chapter 15.1)

